### PR TITLE
Add Go backend server

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,1 +1,33 @@
-Portal project for poc authentication
+# Next.js Portal Demo
+
+This project demonstrates a basic portal built with Next.js and NextAuth. It includes product management and user management pages with simple role based access control.
+
+## Features
+
+- Sign in using credentials handled by **NextAuth**.
+- Two predefined users:
+  - **admin@example.com** / **adminpass** (admin role)
+  - **user@example.com** / **userpass** (user role)
+- Product list accessible to any signed in user.
+- User management page accessible only to admins.
+
+## Running locally
+
+```bash
+npm install
+npm run dev
+```
+
+Then open [http://localhost:3000](http://localhost:3000) in your browser.
+
+### Backend (Go)
+
+The repository also includes a small Go server exposing the user and product
+lists. To run it:
+
+```bash
+cd backend
+go run main.go
+```
+
+The API will be available on `http://localhost:8080`.

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,0 +1,3 @@
+module portal-backend
+
+go 1.23.8

--- a/backend/main.go
+++ b/backend/main.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type User struct {
+	ID       int    `json:"id"`
+	Name     string `json:"name"`
+	Email    string `json:"email"`
+	Password string `json:"password,omitempty"`
+	Role     string `json:"role"`
+}
+
+var users = []User{
+	{ID: 1, Name: "Admin User", Email: "admin@example.com", Password: "adminpass", Role: "admin"},
+	{ID: 2, Name: "Regular User", Email: "user@example.com", Password: "userpass", Role: "user"},
+}
+
+type Product struct {
+	ID    int     `json:"id"`
+	Name  string  `json:"name"`
+	Price float64 `json:"price"`
+}
+
+var products = []Product{
+	{ID: 1, Name: "Product A", Price: 10},
+	{ID: 2, Name: "Product B", Price: 20},
+	{ID: 3, Name: "Product C", Price: 30},
+}
+
+func main() {
+	http.HandleFunc("/users", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(users)
+	})
+	http.HandleFunc("/products", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(products)
+	})
+	http.HandleFunc("/login", loginHandler)
+	http.ListenAndServe(":8080", nil)
+}
+
+func loginHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	var cred struct {
+		Email    string `json:"email"`
+		Password string `json:"password"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&cred); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	for _, u := range users {
+		if u.Email == cred.Email && u.Password == cred.Password {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(struct {
+				ID    int    `json:"id"`
+				Name  string `json:"name"`
+				Email string `json:"email"`
+				Role  string `json:"role"`
+			}{u.ID, u.Name, u.Email, u.Role})
+			return
+		}
+	}
+	w.WriteHeader(http.StatusUnauthorized)
+}

--- a/lib/products.js
+++ b/lib/products.js
@@ -1,0 +1,5 @@
+export const products = [
+  { id: 1, name: 'Product A', price: 10 },
+  { id: 2, name: 'Product B', price: 20 },
+  { id: 3, name: 'Product C', price: 30 }
+]

--- a/lib/users.js
+++ b/lib/users.js
@@ -1,0 +1,16 @@
+export const users = [
+  {
+    id: 1,
+    name: 'Admin User',
+    email: 'admin@example.com',
+    password: 'adminpass',
+    role: 'admin'
+  },
+  {
+    id: 2,
+    name: 'Regular User',
+    email: 'user@example.com',
+    password: 'userpass',
+    role: 'user'
+  }
+]

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+}
+
+module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "portal",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.5.6",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "next-auth": "4.22.1"
+  }
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,9 @@
+import { SessionProvider } from 'next-auth/react'
+
+export default function App({ Component, pageProps: { session, ...pageProps } }) {
+  return (
+    <SessionProvider session={session}>
+      <Component {...pageProps} />
+    </SessionProvider>
+  )
+}

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -1,0 +1,43 @@
+import NextAuth from 'next-auth'
+import CredentialsProvider from 'next-auth/providers/credentials'
+import { users } from '../../../lib/users'
+
+export default NextAuth({
+  providers: [
+    CredentialsProvider({
+      name: 'Credentials',
+      credentials: {
+        email: { label: 'Email', type: 'email', placeholder: 'email@example.com' },
+        password: { label: 'Password', type: 'password' }
+      },
+      async authorize(credentials) {
+        const user = users.find(
+          u => u.email === credentials.email && u.password === credentials.password
+        )
+        if (user) {
+          return user
+        }
+        return null
+      }
+    })
+  ],
+  callbacks: {
+    async session({ session, token, user }) {
+      if (token) {
+        session.user.role = token.role
+        session.user.id = token.id
+      }
+      return session
+    },
+    async jwt({ token, user }) {
+      if (user) {
+        token.role = user.role
+        token.id = user.id
+      }
+      return token
+    }
+  },
+  pages: {
+    signIn: '/login'
+  }
+})

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,27 @@
+import Link from 'next/link'
+import { useSession, signOut } from 'next-auth/react'
+
+export default function Home() {
+  const { data: session } = useSession()
+
+  return (
+    <div>
+      <h1>Portal Home</h1>
+      {session ? (
+        <>
+          <p>Signed in as {session.user.email} ({session.user.role})</p>
+          <button onClick={() => signOut()}>Sign out</button>
+          <ul>
+            <li><Link href="/products">Products</Link></li>
+            <li><Link href="/users">Users</Link></li>
+          </ul>
+        </>
+      ) : (
+        <>
+          <p>You are not signed in</p>
+          <Link href="/login">Sign in</Link>
+        </>
+      )}
+    </div>
+  )
+}

--- a/pages/login.js
+++ b/pages/login.js
@@ -1,0 +1,26 @@
+import { getCsrfToken, signIn } from 'next-auth/react'
+
+export default function Login({ csrfToken }) {
+  return (
+    <form method="post" action="/api/auth/callback/credentials">
+      <input name="csrfToken" type="hidden" defaultValue={csrfToken} />
+      <label>
+        Email
+        <input name="email" type="email" />
+      </label>
+      <label>
+        Password
+        <input name="password" type="password" />
+      </label>
+      <button type="submit">Sign in</button>
+    </form>
+  )
+}
+
+export async function getServerSideProps(context) {
+  return {
+    props: {
+      csrfToken: await getCsrfToken(context)
+    }
+  }
+}

--- a/pages/products.js
+++ b/pages/products.js
@@ -1,0 +1,30 @@
+import { getSession } from 'next-auth/react'
+import { products } from '../lib/products'
+
+export default function Products({ products }) {
+  return (
+    <div>
+      <h1>Products</h1>
+      <ul>
+        {products.map(p => (
+          <li key={p.id}>{p.name} - ${p.price}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+export async function getServerSideProps(context) {
+  const session = await getSession(context)
+  if (!session) {
+    return {
+      redirect: {
+        destination: '/login',
+        permanent: false
+      }
+    }
+  }
+  return {
+    props: { products }
+  }
+}

--- a/pages/unauthorized.js
+++ b/pages/unauthorized.js
@@ -1,0 +1,8 @@
+export default function Unauthorized() {
+  return (
+    <div>
+      <h1>Access Denied</h1>
+      <p>You do not have permission to view this page.</p>
+    </div>
+  )
+}

--- a/pages/users.js
+++ b/pages/users.js
@@ -1,0 +1,38 @@
+import { getSession } from 'next-auth/react'
+import { users } from '../lib/users'
+
+export default function Users({ users }) {
+  return (
+    <div>
+      <h1>User Management</h1>
+      <ul>
+        {users.map(u => (
+          <li key={u.id}>{u.name} - {u.email} ({u.role})</li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+export async function getServerSideProps(context) {
+  const session = await getSession(context)
+  if (!session) {
+    return {
+      redirect: {
+        destination: '/login',
+        permanent: false
+      }
+    }
+  }
+  if (session.user.role !== 'admin') {
+    return {
+      redirect: {
+        destination: '/unauthorized',
+        permanent: false
+      }
+    }
+  }
+  return {
+    props: { users }
+  }
+}


### PR DESCRIPTION
## Summary
- add a simple Go API server with in-memory users and products
- document how to run the Go backend

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: next not found)*
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_b_6864ab275b508329a29e0a6fd35bbf27