### PR TITLE
Set NextAuth session to 30 minutes

### DIFF
--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -51,6 +51,10 @@ export default NextAuth({
   },
   session: {
     strategy: 'jwt',
+    maxAge: 30 * 60, // 30 minutes
+  },
+  jwt: {
+    maxAge: 30 * 60,
   },
   secret: process.env.NEXTAUTH_SECRET,
   debug: process.env.NODE_ENV === 'development',


### PR DESCRIPTION
## Summary
- configure NextAuth sessions to expire after 30 minutes

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6864b7522a3483299c1c72cf823a44a2