### PR TITLE
Fetch products from Go backend

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,3 +1,4 @@
 # NextAuth.js Configuration
 NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=b+oymao8jORrglgOvW6y+2klGoxHrM8FNozlYMW2WNA=
+BACKEND_URL=http://localhost:8080

--- a/Readme.md
+++ b/Readme.md
@@ -22,6 +22,9 @@ npm run dev
 Then open [http://localhost:3000](http://localhost:3000) in your browser.
 Tailwind CSS is configured in `styles/globals.css`.
 
+The products page now fetches its data from the Go backend. Set `BACKEND_URL` in
+`.env.local` if your backend runs on a different address.
+
 ### Backend (Go)
 
 The repository also includes a small Go server exposing the user and product

--- a/pages/products.js
+++ b/pages/products.js
@@ -1,6 +1,5 @@
 import Link from 'next/link'
 import { getSession } from 'next-auth/react'
-import { products } from '../lib/products'
 
 export default function Products({ products }) {
   return (
@@ -30,6 +29,11 @@ export async function getServerSideProps(context) {
       }
     }
   }
+
+  const backendUrl = process.env.BACKEND_URL || 'http://localhost:8080'
+  const res = await fetch(`${backendUrl}/products`)
+  const products = await res.json()
+
   return {
     props: { products }
   }


### PR DESCRIPTION
## Summary
- load products from the Go API instead of a static file
- document new `BACKEND_URL` configuration for the frontend

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6864be93bbdc83298635141648263d9b