### PR TITLE
Handle backend failure on product listing

### DIFF
--- a/pages/products.js
+++ b/pages/products.js
@@ -1,17 +1,21 @@
 import Link from 'next/link'
 import { getSession } from 'next-auth/react'
 
-export default function Products({ products }) {
+export default function Products({ products, error }) {
   return (
     <div className="p-8">
       <h1 className="text-2xl font-bold mb-4">Products</h1>
-      <ul className="space-y-2">
-        {products.map(p => (
-          <li key={p.id} className="border rounded p-4 shadow">
-            {p.name} - ${p.price}
-          </li>
-        ))}
-      </ul>
+      {error ? (
+        <p className="text-red-600 mb-4">Failed to load products.</p>
+      ) : (
+        <ul className="space-y-2">
+          {products.map(p => (
+            <li key={p.id} className="border rounded p-4 shadow">
+              {p.name} - ${p.price}
+            </li>
+          ))}
+        </ul>
+      )}
       <Link className="mt-4 inline-block text-blue-600 underline" href="/">
         Back
       </Link>
@@ -31,10 +35,23 @@ export async function getServerSideProps(context) {
   }
 
   const backendUrl = process.env.BACKEND_URL || 'http://localhost:8080'
-  const res = await fetch(`${backendUrl}/products`)
-  const products = await res.json()
+  let products = []
+  let error = false
+
+  try {
+    const res = await fetch(`${backendUrl}/products`)
+    if (res.ok) {
+      products = await res.json()
+    } else {
+      console.error('Failed to fetch products:', res.status, res.statusText)
+      error = true
+    }
+  } catch (err) {
+    console.error('Error connecting to backend:', err)
+    error = true
+  }
 
   return {
-    props: { products }
+    props: { products, error }
   }
 }


### PR DESCRIPTION
## Summary
- add error handling to `getServerSideProps` in `pages/products.js`
- show friendly message when product fetch fails

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6864ead78508832986da67db6076a780